### PR TITLE
Remove non-ascii character from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ What is this?
 This is a **cli** project to support encryption/decryption
 of expendable notes
 
-What this isn’t
+What this isn't
 ---------------
 
 UI/Frontend/Backend. This is a **cli** project. Frontend and


### PR DESCRIPTION
This character was actually an issue when trying to compile a debian package:
```
dh clean --with python3 --buildsystem=pybuild
   dh_testdir -O--buildsystem=pybuild
   dh_auto_clean -O--buildsystem=pybuild
I: pybuild base:184: python3.5 setup.py clean 
Traceback (most recent call last):
  File "setup.py", line 9, in <module>
    readme = readme_file.read()
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 629: ordinal not in range(128)
E: pybuild pybuild:283: clean: plugin distutils failed with: exit code=1: python3.5 setup.py clean 
dh_auto_clean: pybuild --clean -i python{version} -p 3.5 returned exit code 13
debian/rules:5: recipe for target 'clean' failed
make: *** [clean] Error 25
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
```